### PR TITLE
Check ja/hotel japanese voice functionality

### DIFF
--- a/public/locales/ja.json
+++ b/public/locales/ja.json
@@ -1,0 +1,203 @@
+{
+  "scenes": {
+    "airport": {
+      "messages": [
+          {
+            "number": "1",
+            "romaji": "Kokoro ga jinwari shimashita.",
+            "text": "心が<b>じんわり</b>しました。",
+            "note": "（「日本へようこそ」と言われて、本当に歓迎されていると感じました）",
+            "ja": "心がじんわりしました。",
+            "isFavorite": false
+          },
+          {
+            "number": "2",
+            "romaji": "Kokoro ga hotto shimashita.",
+            "text": "心が<b>ほっと</b>しました。",
+            "note": "（小さな親切が、安心と気遣いを感じさせてくれました）",
+            "ja": "心がほっとしました。",
+            "isFavorite": false
+          },
+          {
+            "number": "3",
+            "romaji": "Kokoro ga kyun to shimashita.",
+            "text": "心が<b>キュンと</b>しました。",
+            "note": "（こんな気遣いは期待していなかったので、本当に良い意味で感動しました）",
+            "ja": "心がキュンとしました。",
+            "isFavorite": false
+          },
+          {
+            "number": "4",
+            "romaji": "Kokoro ga iyasare mashita.",
+            "text": "心が癒されました。",
+            "note": "（長旅の疲れが一気に取れた気がしました）",
+            "ja": "心が癒されました。",
+            "isFavorite": false
+          },
+          {
+            "number": "5",
+            "romaji": "Kokoro kara kansha shimashita.",
+            "text": "心から感謝しました。",
+            "note": "（親切な対応に心から感謝しました）",
+            "ja": "心から感謝しました。",
+            "isFavorite": false
+          },
+          {
+            "number": "6",
+            "romaji": "Kokoro ga jiwan to shimashita.",
+            "text": "心が<b>じわ～んと</b>しました。",
+            "note": "（温かい言葉に胸が熱くなりました）",
+            "ja": "心がじわ～んとしました。",
+            "isFavorite": false
+          },
+          {
+            "number": "7",
+            "romaji": "Kokoro ga uruuru shimashita.",
+            "text": "心が<b>うるうる</b>しました。",
+            "note": "（感動して涙が出そうになりました）",
+            "ja": "心がうるうるしました。",
+            "isFavorite": false
+          },
+          {
+            "number": "8",
+            "romaji": "Kokoro ga fuwatto nagomimashita.",
+            "text": "心が<b>ふわっと</b>和みました。",
+            "note": "（優しい雰囲気に癒されました）",
+            "ja": "心がふわっと和みました。",
+            "isFavorite": false
+          },
+          {
+            "number": "9",
+            "romaji": "Kokoro ga wakuwaku shimashita.",
+            "text": "心が<b>ワクワク</b>しました。",
+            "note": "（新しい体験に胸が高鳴りました）",
+            "ja": "心がワクワクしました。",
+            "isFavorite": false
+          },
+          {
+            "number": "10",
+            "romaji": "Kokoro ga atatakaku narimashita.",
+            "text": "心が温かくなりました。",
+            "note": "（人の優しさに触れて心が温まりました）",
+            "ja": "心が温かくなりました。",
+            "isFavorite": false
+          },
+          {
+            "number": "11",
+            "romaji": "Kokoro ga pokapoka shimashita.",
+            "text": "心が<b>ぽかぽか</b>しました。",
+            "note": "（ほっとする瞬間でした）",
+            "ja": "心がぽかぽかしました。",
+            "isFavorite": false
+          },
+          {
+            "number": "12",
+            "romaji": "Kokoro ga jiin to shimashita.",
+            "text": "心が<b>じーんと</b>しました。",
+            "note": "（感動で胸がいっぱいになりました）",
+            "ja": "心がじーんとしました。",
+            "isFavorite": false
+          },
+          {
+            "number": "13",
+            "romaji": "Kokoro ga hotto shimashita.",
+            "text": "心が<b>ほっと</b>しました。",
+            "note": "（安心感に包まれました）",
+            "ja": "心がほっとしました。",
+            "isFavorite": false
+          },
+          {
+            "number": "14",
+            "romaji": "Kokoro ga hazumi mashita.",
+            "text": "心が弾みました。",
+            "note": "（期待で胸が弾みました）",
+            "ja": "心が弾みました。",
+            "isFavorite": false
+          },
+          {
+            "number": "15",
+            "romaji": "Kokoro ga hodokemashita.",
+            "text": "心がほどけました。",
+            "note": "（緊張がほぐれました）",
+            "ja": "心がほどけました。",
+            "isFavorite": false
+          },
+          {
+            "number": "16",
+            "romaji": "Kokoro ga tokimeki mashita.",
+            "text": "心が<b>ときめき</b>ました。",
+            "note": "（新しい出会いに心がときめきました）",
+            "ja": "心がときめきました。",
+            "isFavorite": false
+          }
+        ] 
+    },
+    "hotel": {
+      "messages": [
+        { "number": "1", "romaji": "Wakuwaku shinagara chekkuin wo mukaemashita", "text": "《ワクワク》しながらチェックインを迎えました", "note": "（丁寧なご案内に、旅の始まりの期待がさらにふくらみました）", "ja": "ワクワクしながらチェックインを迎えました", "isFavorite": false },
+        { "number": "2", "romaji": "Arigatou gozaimasu. Hokkori shimashita", "text": "ありがとうございます。《ほっこり》しました。", "note": "（チェックイン時、笑顔で出迎えてくれたフロントスタッフに）", "ja": "ありがとうございます。ほっこりしました。", "isFavorite": false },
+        { "number": "3", "romaji": "Oheya no kaori ga kimochi ii desu ne. Arigatou gozaimasu", "text": "お部屋の香りが気持ちいいですね。ありがとうございます", "note": "（お部屋の香りが気に入ったとき）", "ja": "お部屋の香りが気持ちいいですね。ありがとうございます", "isFavorite": false },
+        { "number": "4", "romaji": "Oheya no seiketsukan ni, kokoro ga haremashita", "text": "お部屋の清潔感に、心が晴れました", "note": "（清掃の方の丁寧なお仕事に気づき、温かさを感じました）", "ja": "お部屋の清潔感に、心が晴れました", "isFavorite": false },
+        { "number": "5", "romaji": "Arigatou gozaimasu. Pikapika ni shite kudasatte kangeki desu", "text": "ありがとうございます。《ピカピカ》にしてくださって感激です。", "note": "（お部屋の清掃が完璧で、まるで新しいお部屋のように感じたとき）", "ja": "ありがとうございます。ピカピカにしてくださって感激です。", "isFavorite": false },
+        { "number": "6", "romaji": "Arigatou gozaimasu. Komaka na kikubari ga ureshikatta desu", "text": "ありがとうございます。細かな気配りが嬉しかったです。", "note": "（部屋に置かれたメモ、加湿器、絵葉書など細かな心配りに）", "ja": "ありがとうございます。細かな気配りが嬉しかったです。", "isFavorite": false },
+        { "number": "7", "romaji": "Nagame ni uttori shimashita", "text": "眺めに《うっとり》しました", "note": "（窓を開けた瞬間、まるで絵画の中に入り込んだようでした）", "ja": "眺めにうっとりしました", "isFavorite": false },
+        { "number": "8", "romaji": "Egao ni hokkori shimashita", "text": "笑顔に《ほっこり》しました。", "note": "（言葉よりも伝わるやさしさが、胸にしみました）", "ja": "笑顔にほっこりしました。", "isFavorite": false },
+        { "number": "9", "romaji": "O kokoro kubari, hontou ni arigatou gozaimasu", "text": "お心配り、本当にありがとうございます。", "note": "（こちらの気持ちを先回りしたご案内がとてもありがたかったです）", "ja": "お心配り、本当にありがとうございます。", "isFavorite": false },
+        { "number": "10", "romaji": "Arigatou gozaimasu. Uruuru kichaimashita", "text": "ありがとうございます。《うるうる》きちゃいました。", "note": "（コンシェルジュが旅の記念にメッセージカードを添えてくれたとき）", "ja": "ありがとうございます。うるうるきちゃいました。", "isFavorite": false },
+        { "number": "11", "romaji": "Kokoro made pokapoka ni narimashita. Arigatou gozaimasu", "text": "心まで《ぽかぽか》になりました。ありがとうございます", "note": "（素晴らしいお風呂に対する感想）", "ja": "心までぽかぽかになりました。ありがとうございます", "isFavorite": false },
+        { "number": "12", "romaji": "Arigatou gozaimasu. Torotoro ni tokesou desu", "text": "ありがとうございます。《とろとろ》にとけそうです。", "note": "（温泉で体の芯まで温まり、癒やされた瞬間に）", "ja": "ありがとうございます。とろとろにとけそうです。", "isFavorite": false },
+        { "number": "13", "romaji": "Oryouri no hitosara hitosara ni wakuwaku ga tsumatte imashita", "text": "お料理のひと皿ひと皿に《ワクワク》が詰まっていました", "note": "（見た目も味も、まるで物語をいただくようでした）", "ja": "お料理のひと皿ひと皿にワクワクが詰まっていました", "isFavorite": false },
+        { "number": "14", "romaji": "Arigatou gozaimasu. Dokidoki ga tomarimasen", "text": "ありがとうございます。《ドキドキ》が止まりません。", "note": "（運ばれてくる料理とお品書きに感動して、レストランのスタッフに）", "ja": "ありがとうございます。ドキドキが止まりません。", "isFavorite": false },
+        { "number": "15", "romaji": "Chefu no omoi ga tsutawaru ryouri ni, kokoro ga jinwari atatakarimashita", "text": "シェフの想いが伝わる料理に、心がじんわり温まりました", "note": "（ただの食事ではなく、心を込めてくださった時間を感じました）", "ja": "シェフの想いが伝わる料理に、心がじんわり温まりました", "isFavorite": false },
+        { "number": "16", "romaji": "Ofuton ga fukafuka de, tsutsumareru you na anshinkan deshita", "text": "お布団が《ふかふか》で、包まれるような安心感でした", "note": "（旅の疲れがスッと取れていくのを感じました）", "ja": "お布団がふかふかで、包まれるような安心感でした", "isFavorite": false },
+        { "number": "17", "romaji": "Arigatou gozaimasu. Howahowa shiawase kibun desu", "text": "ありがとうございます。《ほわほわ》幸せ気分です。", "note": "（ふかふかのお布団にくるまりながら、快適な寝具の用意に）", "ja": "ありがとうございます。ほわほわ幸せ気分です。", "isFavorite": false },
+        { "number": "18", "romaji": "Arigatou gozaimasu. Fuwafuwa yume gokochi deshita", "text": "ありがとうございます。《ふわふわ》夢ごこちでした。", "note": "（ベッドの寝心地と、夜の静けさが完璧でぐっすり眠れたとき）", "ja": "ありがとうございます。ふわふわ夢ごこちでした。", "isFavorite": false },
+        { "number": "19", "romaji": "Arigatou gozaimasu. Tsuyatsuya gohan, saikou deshita", "text": "ありがとうございます。《つやつや》ご飯、最高でした。", "note": "（朝食のごはんがふっくら美味しくて、食事処の方に）", "ja": "ありがとうございます。つやつやご飯、最高でした。", "isFavorite": false },
+        { "number": "20", "romaji": "Arigatou gozaimasu. Mata kimasu", "text": "ありがとうございます。また来ます。", "note": "（チェックアウト時、「またお待ちしています」と手を振ってくれたスタッフに）", "ja": "ありがとうございます。また来ます。", "isFavorite": false }
+      ]
+    },
+    "restaurant": {
+      "messages": [
+        { "number": "1", "romaji": "KONNA KIZUKAI NI, 《JIIN》 TO KIMASHITA", "text": "こんな気遣いに、《じ〜ん》ときました。", "note": "（料理を分けやすいようにお皿を追加してくれたスタッフの優しさに）", "ja": "こんな気遣いに、じーんときました。", "isFavorite": false },
+        { "number": "2", "romaji": "TEPPAN WO KAKONDE NO JIKAN GA, OMOIDE NI KAWARIMASHITA", "text": "鉄板を囲んでの時間が、思い出に変わりました。", "note": "（鉄板を囲んで、会話と笑顔が広がったとき）", "ja": "鉄板を囲んでの時間が、思い出に変わりました。", "isFavorite": false },
+        { "number": "3", "romaji": "ANATA NO EGAO GA KOKORO NI SHIMIMASHITA", "text": "あなたの笑顔が心に沁みました。", "note": "（にこやかに話しかけてくれたスタッフのおかげで、緊張がほぐれたとき）", "ja": "あなたの笑顔が心に沁みました。", "isFavorite": false }
+      ]
+    },
+    "shopping": {
+      "messages": [
+        { "number": "1", "romaji": "Oshiguzu ni deatte, kokoro ga kyunkyun shimashita", "text": "推しグッズに出会えて、心が《キュンキュン》しました。", "note": "（まるで夢の国に来た気分です）", "ja": "推しグッズに出会えて、心がキュンキュンしました。", "isFavorite": false },
+        { "number": "2", "romaji": "Kagami no naka no jibun ni, kokoro ga tokimekimashita", "text": "鏡の中の自分に、心が《ときめき》ました。", "note": "（着物って、思ったより似合ってるかも…）", "ja": "鏡の中の自分に、心がときめきました。", "isFavorite": false },
+        { "number": "3", "romaji": "Kore, mita shunkan ni kokoro ga pin to shimashita", "text": "これ、見た瞬間に心が《ピンと》きました！", "note": "（ときめきを伝える一言）", "ja": "これ、見た瞬間に心がピンときました！", "isFavorite": false }
+      ]
+    },
+    "transportation": {
+      "messages": [
+        {
+          "number": "1",
+          "romaji": "KIPPU KOUNYUU O OTETSUDIAI ITADAKI ARIGATOU GOZAIMASU",
+          "text": "切符購入をお手伝いいただきありがとうございます",
+          "note": "（外国語が通じにくい中、窓口や駅員さんのサポートで安心できたシーン）",
+          "ja": "切符購入をお手伝いいただきありがとうございます",
+          "isFavorite": false
+        },
+        {
+          "number": "2",
+          "romaji": "EIGO ANNAI O MITSUKETE KURETE TASUKARIMASHITA",
+          "text": "英語案内を見つけてくれて助かりました",
+          "note": "（案内表示が小さかったり、翻訳が不明瞭な中での感謝）",
+          "ja": "英語案内を見つけてくれて助かりました",
+          "isFavorite": false
+        },
+        {
+          "number": "3",
+          "romaji": "TEINEI NI OSHIETE KURETE, HONTŌ NI KOKOROZUYOKATTA DESU",
+          "text": "丁寧に教えてくれて、本当に心強かったです",
+          "note": "（地方や初乗車で困った時に現地の人が助けてくれた状況）",
+          "ja": "丁寧に教えてくれて、本当に心強かったです",
+          "isFavorite": false
+        }
+      ]
+    }
+  },
+  "ありがとう": "ありがとう！"
+}


### PR DESCRIPTION
Add `ja` and `isFavorite` fields to `ja.json` and complete its structure to enable Japanese audio playback.

---
<a href="https://cursor.com/background-agent?bcId=bc-ed8871f3-41e2-4ab5-9f35-2037c11febb0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ed8871f3-41e2-4ab5-9f35-2037c11febb0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>