### PR TITLE
chore: public/index.html を新規追加（public をサイトルートに統一）

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,17 @@
+﻿<!doctype html>
+<html lang="ja">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Arigato App</title>
+</head>
+<body>
+  <div id="app"></div>
+
+  <!-- アプリ本体 -->
+  <script src="script.js"></script>
+
+  <!-- 検証ページへのリンク（任意） -->
+  <p style="margin-top:16px"><a href="/verify.html">verify.html</a></p>
+</body>
+</html>


### PR DESCRIPTION
## Why
- Vercel の Output Directory を public に固定する運用のため、サイトのエントリーポイントとして public/index.html が必要。

## What
- public/index.html を追加
- <div id="app"></div> を配置（クライアント側マウント先）
- script.js を読み込み（今後の機能拡張用フック）
- ページ下部に /verify.html への暫定リンクを設置

## Impact
- 既存機能への破壊的変更なし（新規ファイルのみ）

## Checks
- [ ] ローカルで public/index.html を開き、コンソールエラーがないこと
- [ ] Vercel Preview で / が 200 を返すこと
- [ ] verify.html が存在する場合、リンクが有効に遷移すること

## After Merge
- main へ Squash/Merge → Vercel 本番が自動デプロイ（Output Directory = public）
