### PR TITLE
feat(verify): dictionary preview + scenes scaffold; connect dictionary.json

### DIFF
--- a/public/data/dictionary.json
+++ b/public/data/dictionary.json
@@ -1,0 +1,30 @@
+﻿[
+    {
+        "id":  {
+
+               },
+        "sceneId":  {
+
+                    },
+        "scene":  "和食・伝統料理",
+        "main":  "お味噌汁から《ほわ〜》と湯気が立ちのぼりました。",
+        "romaji":  "OMISOSHIRU KARA 《HOWA〜》 TO YUGE GA TACHINOBORIMASHITA",
+        "description":  {
+                            "ja":  "あたたかい蒸気がゆっくり広がる情景。"
+                        }
+    },
+    {
+        "id":  {
+
+               },
+        "sceneId":  {
+
+                    },
+        "scene":  "和食・伝統料理",
+        "main":  "焼き魚の皮が《パリッ》とはじける音が心地よかったです。",
+        "romaji":  "YAKIZAKANA NO KAWA GA 《PARI》 TO HAJIKERU OTO GA KOKOCHI YOKATTA DESU",
+        "description":  {
+                            "ja":  "香ばしさを引き立てる軽やかな割れ音。"
+                        }
+    }
+]

--- a/public/data/scenes/scene28.json
+++ b/public/data/scenes/scene28.json
@@ -1,0 +1,20 @@
+﻿[
+  {
+    "id": 406,
+    "sceneId": 28,
+    "scene": "和食・伝統料理",
+    "main": "お味噌汁から《ほわ〜》と湯気が立ちのぼりました。",
+    "romaji": "OMISOSHIRU KARA 《HOWA〜》 TO YUGE GA TACHINOBORIMASHITA",
+    "translation": { "en": "", "zh": "", "ko": "" },
+    "description": { "ja": "あたたかい蒸気がゆっくり広がる情景。" }
+  },
+  {
+    "id": 407,
+    "sceneId": 28,
+    "scene": "和食・伝統料理",
+    "main": "焼き魚の皮が《パリッ》とはじける音が心地よかったです。",
+    "romaji": "YAKIZAKANA NO KAWA GA 《PARI》 TO HAJIKERU OTO GA KOKOCHI YOKATTA DESU",
+    "translation": { "en": "", "zh": "", "ko": "" },
+    "description": { "ja": "香ばしさを引き立てる軽やかな割れ音。" }
+  }
+]

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,17 @@
+﻿<!doctype html>
+<html lang="ja">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Arigato App</title>
+</head>
+<body>
+  <div id="app"></div>
+
+  <!-- アプリ本体 -->
+  <script src="script.js"></script>
+
+  <!-- 検証ページへのリンク（任意） -->
+  <p style="margin-top:16px"><a href="/verify.html">verify.html</a></p>
+</body>
+</html>

--- a/public/verify.css
+++ b/public/verify.css
@@ -1,0 +1,33 @@
+:root { --fg:#111; --muted:#666; --border:#e5e7eb; }
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  font-family: system-ui, -apple-system, Segoe UI, Roboto, "Hiragino Kaku Gothic ProN", Meiryo, sans-serif;
+  color: var(--fg);
+}
+.container { max-width: 860px; margin: 24px auto; padding: 0 16px; }
+
+h1 { font-size: 28px; margin: 0 0 12px; }
+h2 { font-size: 22px; margin: 20px 0 12px; }
+
+.status-row { display: flex; gap: 12px; align-items: center; flex-wrap: wrap; }
+
+.badge {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 6px 10px; border: 1px solid #16a34a; color: #16a34a;
+  border-radius: 999px; font-size: 14px;
+}
+.on { color: #16a34a; font-weight: 700; } /* Premium ON 表示 */
+
+.btn { padding: 8px 12px; border: 1px solid var(--border); border-radius: 10px; background: #fff; cursor: pointer; font-size: 14px; }
+.btn[aria-pressed="true"] { background: #111; color: #fff; }
+
+.divider { height: 8px; border: none; background: #111; margin: 16px 0 12px; border-radius: 999px; }
+
+.list { display: grid; grid-template-columns: 1fr; gap: 10px; }
+.card { border: 1px solid var(--border); border-radius: 14px; padding: 12px; }
+.card-head { display: flex; align-items: center; justify-content: space-between; gap: 8px; }
+.card-title { font-weight: 600; }
+.card-sub { color: var(--muted); font-size: 12px; margin-top: 4px; }
+.card-actions { display: flex; gap: 8px; }
+.small { padding: 6px 10px; font-size: 12px; }

--- a/public/verify.css
+++ b/public/verify.css
@@ -31,3 +31,22 @@ h2 { font-size: 22px; margin: 20px 0 12px; }
 .card-sub { color: var(--muted); font-size: 12px; margin-top: 4px; }
 .card-actions { display: flex; gap: 8px; }
 .small { padding: 6px 10px; font-size: 12px; }
+/* === dictionary cards === */
+.dict { margin-block: 24px; }
+.controls { display: flex; gap: 10px; align-items: center; flex-wrap: wrap; margin-bottom: 12px; }
+.controls input[type="search"] { padding: 6px 8px; min-width: 240px; }
+.controls select { padding: 6px 8px; }
+#count { opacity: 0.8; }
+
+.cards-grid { display: grid; gap: 12px; grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); }
+
+.card { border: 1px solid #e5e7eb; border-radius: 12px; padding: 12px; background: #fff; }
+.card h3 { font-size: 1rem; margin: 0 0 6px; display: flex; justify-content: space-between; gap: 8px; }
+.card .scene { font-size: 0.75rem; opacity: 0.7; }
+
+.card .main { font-weight: 600; line-height: 1.5; }
+.card .romaji { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 0.85rem; opacity: 0.9; margin-top: 6px; word-break: break-word; }
+.card .desc { font-size: 0.9rem; margin-top: 8px; line-height: 1.6; }
+
+/* 《オノマトペ》強調 */
+.card .main .ono { font-weight: 800; }

--- a/public/verify.html
+++ b/public/verify.html
@@ -4,135 +4,31 @@
   <meta charset="utf-8" />
   <meta name="robots" content="noindex" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Verify Premium</title>
-  <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, "Noto Sans", sans-serif; margin: 24px; line-height: 1.6; }
-    .row { margin: 12px 0; }
-    .on { color: #22c55e; font-weight: 700; }
-    button { font-size: 16px; padding: 8px 12px; border-radius: 10px; border: 1px solid #ccc; background: #f5f5f5; }
-    button:active { transform: translateY(1px); }
-    pre { background: #111; color: #eee; padding: 8px; border-radius: 8px; max-height: 220px; overflow: auto; }
-  </style>
+  <title>Verification | Arigato App</title>
+  <link rel="stylesheet" href="/verify.css" />
 </head>
 <body>
-  <h1>Verification</h1>
+  <main class="container">
+    <h1>Verification</h1>
 
-  <div class="row">
-    Premium:
-    <span id="premium" data-testid="premium-indicator" data-status="off">OFF</span>
-  </div>
+    <section class="status-row">
+      <span id="premium" data-testid="premium-indicator" class="badge">OFF</span>
+      <button id="star" data-testid="star-toggle" class="btn" aria-pressed="false">☆ Favorite</button>
+      <button id="audio" data-testid="audio-button" class="btn">🔊 Play test</button>
+    </section>
 
-  <div class="row">
-    <button id="star" data-testid="star-toggle" aria-pressed="false">★ Favorite</button>
-  </div>
+    <!-- Playwright等が読む可能性があるので残します（ログ用） -->
+    <pre id="log" style="display:none"></pre>
 
-  <div class="row">
-    <button id="audio" data-testid="audio-button">🔊 Play test</button>
-  </div>
+    <hr class="divider" />
 
-  <pre id="log"></pre>
+    <h2>Dictionary Preview</h2>
+    <div id="dict-list" class="list"></div>
+  </main>
 
-  <hr />
-  <h2>Dictionary Preview</h2>
-  <div id="dict-list"></div>
-
-  <script>
-    (async function loadDictPreview(){
-      const list = document.getElementById('dict-list');
-
-      async function load(path){
-        try{
-          const res = await fetch(path, {cache:'no-store'});
-          if(!res.ok) throw new Error(res.status+' '+res.statusText);
-          const data = await res.json();
-          return Array.isArray(data) ? data : [];
-        }catch(e){ return []; }
-      }
-
-      // 読み込みパス候補（premium版を優先）
-      const paths = [
-        '/locales/onomatopoeia-premium-all-41-scenes.json',
-        '/locales/onomatopoeia-all-scenes.json'
-      ];
-
-      let data = [];
-      let used = 'NOT-FOUND';
-      for(const p of paths){
-        data = await load(p);
-        if(data.length){ used = p; break; }
-      }
-
-
-
-      // 先頭シーンの上位3件をプレビュー（sceneIdでまとまりを作る）
-      if(!data.length){ return; }
-      const firstSceneId = data[0]?.sceneId ?? null;
-      const rows = data
-        .filter(x => firstSceneId==null ? true : x.sceneId === firstSceneId)
-        .slice(0, 3);
-
-      for(const item of rows){
-        const title = (item.main||'').trim();
-        const romaji = (item.romaji||'').trim();
-        const desc = (typeof item.description === 'string'
-                        ? item.description
-                        : (item.description?.ja || item.description?.en || item.description?.zh || item.description?.ko || '')
-                     ).trim();
-
-        const el = document.createElement('div');
-        el.setAttribute('data-testid','dict-row');
-        el.style.padding = '8px 0';
-        el.innerHTML = `
-          <div data-testid="dict-title">${title}</div>
-          ${romaji ? `<div data-testid="dict-romaji">${romaji}</div>` : ''}
-          ${desc ? `<div data-testid="dict-desc">${desc}</div>` : ''}
-        `;
-        list.appendChild(el);
-      }
-    })();
-  </script>
-
-  <script>
-    (function () {
-      const premiumEl = document.getElementById('premium');
-      const starBtn   = document.getElementById('star');
-      const audioBtn  = document.getElementById('audio');
-      const log       = document.getElementById('log');
-
-      const setPremium = (on) => {
-        localStorage.setItem('premiumEnabled', on ? '1' : '0');
-        premiumEl.dataset.status = on ? 'on' : 'off';
-        premiumEl.textContent = on ? 'ON' : 'OFF';
-        premiumEl.classList.toggle('on', on);
-      };
-
-      const getFav = () => localStorage.getItem('favoriteTest') === '1';
-      const setFav = (on) => {
-        localStorage.setItem('favoriteTest', on ? '1' : '0');
-        starBtn.setAttribute('aria-pressed', on ? 'true' : 'false');
-      };
-
-      // 初期化：プレミアム強制ON、★はローカルストレージから復元
-      setPremium(true);
-      setFav(getFav());
-
-      starBtn.addEventListener('click', () => {
-        const next = !getFav();
-        setFav(next);
-        log.textContent += 'star:' + next + '\n';
-      });
-
-      audioBtn.addEventListener('click', () => {
-        try {
-          const a = new Audio(); // src不要。Playwright側で play() をモック
-          const p = a.play();
-          if (p && p.catch) p.catch(() => {});
-          log.textContent += 'audio:clicked\n';
-        } catch (e) {
-          log.textContent += 'audio:error ' + e + '\n';
-        }
-      });
-    })();
-  </script>
+  <!-- スモーク時は翻訳OFF -->
+  <script>window.__TRANSLATION_ENABLED__ = 0;</script>
+  <script type="module" src="/verify.js"></script>
 </body>
 </html>
+

--- a/public/verify.html
+++ b/public/verify.html
@@ -19,11 +19,17 @@
 
     <!-- Playwright等が読む可能性があるので残します（ログ用） -->
     <pre id="log" style="display:none"></pre>
-
     <hr class="divider" />
-
-    <h2>Dictionary Preview</h2>
-    <div id="dict-list" class="list"></div>
+    <section class="dict">
+      <h2>辞書プレビュー</h2>
+      <div class="controls">
+        <input id="q" type="search" placeholder="キーワード検索" />
+        <select id="scene"></select>
+        <span id="count" aria-live="polite"></span>
+      </div>
+      <div id="cards" class="cards-grid" role="list"></div>
+    </section>
+     
   </main>
 
   <!-- スモーク時は翻訳OFF -->

--- a/public/verify.js
+++ b/public/verify.js
@@ -1,0 +1,162 @@
+'use strict';
+
+// ===== 要素参照 =====
+const premiumEl = document.getElementById('premium');
+const starBtn   = document.getElementById('star');
+const audioBtn  = document.getElementById('audio');
+const logEl     = document.getElementById('log');
+const listEl    = document.getElementById('dict-list');
+
+const log = (t) => { if (logEl) logEl.textContent += t + '\n'; };
+
+// ===== Premium 表示（常時ON） =====
+function setPremium(on) {
+  // 互換キー（旧verify.htmlと同じキー名）
+  localStorage.setItem('premiumEnabled', on ? '1' : '0');
+  if (!premiumEl) return;
+  premiumEl.dataset.status = on ? 'on' : 'off';
+  premiumEl.textContent = on ? 'ON' : 'OFF';
+  premiumEl.classList.toggle('on', on);
+}
+setPremium(true);
+
+// ===== グローバル Favorite（旧互換：favoriteTest） =====
+const favKeyGlobal = 'favoriteTest';
+const getFav = () => localStorage.getItem(favKeyGlobal) === '1';
+function setFav(on) {
+  localStorage.setItem(favKeyGlobal, on ? '1' : '0');
+  if (!starBtn) return;
+  starBtn.setAttribute('aria-pressed', on ? 'true' : 'false');
+  starBtn.textContent = on ? '★ Favorited' : '☆ Favorite';
+}
+setFav(getFav());
+if (starBtn) {
+  starBtn.addEventListener('click', () => {
+    const next = !getFav();
+    setFav(next);
+    log('star:' + next);
+  });
+}
+
+// ===== 🔊 Play test（Playwright互換＋実音TTS） =====
+if (audioBtn) {
+  audioBtn.addEventListener('click', () => {
+    try {
+      // Playwrightなどの自動テスト向け：必ず play() を呼ぶ
+      const a = new Audio();
+      const p = a.play();
+      if (p && p.catch) p.catch(() => {}); // ブラウザがブロックしても無視
+      log('audio:clicked');
+
+      // 実音：Web Speech API（使えない環境では自動的に無音）
+      if ('speechSynthesis' in window) {
+        const u = new SpeechSynthesisUtterance('ありがとうの気持ち、届いていますか？');
+        u.lang = 'ja-JP';
+        const v = speechSynthesis.getVoices().find(vi => vi.lang && vi.lang.startsWith('ja'));
+        if (v) u.voice = v;
+        speechSynthesis.speak(u);
+      }
+    } catch (e) {
+      log('audio:error ' + e);
+    }
+  });
+}
+
+// ===== Dictionary Preview =====
+(async function loadDictPreview() {
+  if (!listEl) return;
+
+  async function load(path) {
+    try {
+      const res = await fetch(path, { cache: 'no-store' });
+      if (!res.ok) throw new Error(res.status + ' ' + res.statusText);
+      return await res.json();
+    } catch {
+      return null;
+    }
+  }
+
+  // 旧→新の順でフォールバック（旧verify.html互換パスを優先）
+  const candidates = [
+    '/locales/onomatopoeia-premium-all-41-scenes.json',
+    '/locales/onomatopoeia-all-scenes.json',
+    '/data/dictionary.json',
+    '/data/dictionary-sample.json'
+  ];
+
+  let items = [];
+  for (const p of candidates) {
+    const j = await load(p);
+    if (!j) continue;
+    items = Array.isArray(j) ? j : (j.items || []);
+    if (items.length) break;
+  }
+
+  if (!items.length) {
+    listEl.innerHTML = `
+      <div class="card" data-testid="dict-row">
+        <div class="card-title">（プレビュー用データが未配置です）</div>
+        <div class="card-sub">public/data/dictionary.json または dictionary-sample.json を置くと表示されます。</div>
+      </div>`;
+    return;
+  }
+
+  // 先頭シーンの上位3件のみを表示（旧仕様に合わせる）
+  const firstSceneId = items[0]?.sceneId ?? null;
+  const rows = items
+    .filter(x => firstSceneId == null ? true : x.sceneId === firstSceneId)
+    .slice(0, 3);
+
+  listEl.innerHTML = rows.map(toCardHTML).join('');
+
+  // 行内ボタン（🔊/☆）のイベント委譲
+  listEl.addEventListener('click', (e) => {
+    const btn = e.target.closest('button[data-action]');
+    if (!btn) return;
+    const id = btn.dataset.id;
+    if (btn.dataset.action === 'play') {
+      const text = btn.dataset.text || '';
+      try {
+        const u = new SpeechSynthesisUtterance(text.replace(/《|》/g, ''));
+        u.lang = 'ja-JP';
+        speechSynthesis.speak(u);
+      } catch {}
+    }
+    if (btn.dataset.action === 'fav') {
+      const key = `fav:item:${id}`;
+      const on = localStorage.getItem(key) === '1';
+      localStorage.setItem(key, on ? '0' : '1');
+      btn.textContent = on ? '☆' : '★';
+      btn.setAttribute('aria-pressed', on ? 'false' : 'true');
+    }
+  }, { once: true });
+})();
+
+function toCardHTML(it) {
+  const id    = it.id ?? '';
+  const title = (it.main || '').trim();
+  const romaji = (it.romaji || '').trim();
+  const desc  = (typeof it.description === 'string'
+    ? it.description
+    : (it.description?.ja || it.description?.en || it.description?.zh || it.description?.ko || '')
+  ).trim();
+  const favKey = `fav:item:${id}`;
+  const favOn = localStorage.getItem(favKey) === '1';
+
+  return `
+    <article class="card" data-testid="dict-row">
+      <div class="card-head">
+        <div data-testid="dict-title" class="card-title">${escapeHTML(title)}</div>
+        <div class="card-actions">
+          <button class="btn small" data-action="play" data-id="${id}" data-text="${escapeAttr(title)}">🔊 Play</button>
+          <button class="btn small" data-action="fav" data-id="${id}" aria-pressed="${favOn ? 'true' : 'false'}">${favOn ? '★' : '☆'}</button>
+        </div>
+      </div>
+      ${romaji ? `<div data-testid="dict-romaji" class="card-sub">${escapeHTML(romaji)}</div>` : ''}
+      ${desc   ? `<div data-testid="dict-desc"   class="card-sub">${escapeHTML(desc)}</div>`   : ''}
+    </article>
+  `;
+}
+
+function escapeHTML(s){ return String(s).replace(/[&<>"']/g, m => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[m])); }
+function escapeAttr(s){ return String(s).replace(/"/g,'&quot;'); }

--- a/public/verify.legacy.html
+++ b/public/verify.legacy.html
@@ -1,0 +1,138 @@
+<!doctype html>
+<html lang="ja">
+<head>
+  <meta charset="utf-8" />
+  <meta name="robots" content="noindex" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Verify Premium</title>
+  <style>
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, "Noto Sans", sans-serif; margin: 24px; line-height: 1.6; }
+    .row { margin: 12px 0; }
+    .on { color: #22c55e; font-weight: 700; }
+    button { font-size: 16px; padding: 8px 12px; border-radius: 10px; border: 1px solid #ccc; background: #f5f5f5; }
+    button:active { transform: translateY(1px); }
+    pre { background: #111; color: #eee; padding: 8px; border-radius: 8px; max-height: 220px; overflow: auto; }
+  </style>
+</head>
+<body>
+  <h1>Verification</h1>
+
+  <div class="row">
+    Premium:
+    <span id="premium" data-testid="premium-indicator" data-status="off">OFF</span>
+  </div>
+
+  <div class="row">
+    <button id="star" data-testid="star-toggle" aria-pressed="false">★ Favorite</button>
+  </div>
+
+  <div class="row">
+    <button id="audio" data-testid="audio-button">🔊 Play test</button>
+  </div>
+
+  <pre id="log"></pre>
+
+  <hr />
+  <h2>Dictionary Preview</h2>
+  <div id="dict-list"></div>
+
+  <script>
+    (async function loadDictPreview(){
+      const list = document.getElementById('dict-list');
+
+      async function load(path){
+        try{
+          const res = await fetch(path, {cache:'no-store'});
+          if(!res.ok) throw new Error(res.status+' '+res.statusText);
+          const data = await res.json();
+          return Array.isArray(data) ? data : [];
+        }catch(e){ return []; }
+      }
+
+      // 読み込みパス候補（premium版を優先）
+      const paths = [
+        '/locales/onomatopoeia-premium-all-41-scenes.json',
+        '/locales/onomatopoeia-all-scenes.json'
+      ];
+
+      let data = [];
+      let used = 'NOT-FOUND';
+      for(const p of paths){
+        data = await load(p);
+        if(data.length){ used = p; break; }
+      }
+
+
+
+      // 先頭シーンの上位3件をプレビュー（sceneIdでまとまりを作る）
+      if(!data.length){ return; }
+      const firstSceneId = data[0]?.sceneId ?? null;
+      const rows = data
+        .filter(x => firstSceneId==null ? true : x.sceneId === firstSceneId)
+        .slice(0, 3);
+
+      for(const item of rows){
+        const title = (item.main||'').trim();
+        const romaji = (item.romaji||'').trim();
+        const desc = (typeof item.description === 'string'
+                        ? item.description
+                        : (item.description?.ja || item.description?.en || item.description?.zh || item.description?.ko || '')
+                     ).trim();
+
+        const el = document.createElement('div');
+        el.setAttribute('data-testid','dict-row');
+        el.style.padding = '8px 0';
+        el.innerHTML = `
+          <div data-testid="dict-title">${title}</div>
+          ${romaji ? `<div data-testid="dict-romaji">${romaji}</div>` : ''}
+          ${desc ? `<div data-testid="dict-desc">${desc}</div>` : ''}
+        `;
+        list.appendChild(el);
+      }
+    })();
+  </script>
+
+  <script>
+    (function () {
+      const premiumEl = document.getElementById('premium');
+      const starBtn   = document.getElementById('star');
+      const audioBtn  = document.getElementById('audio');
+      const log       = document.getElementById('log');
+
+      const setPremium = (on) => {
+        localStorage.setItem('premiumEnabled', on ? '1' : '0');
+        premiumEl.dataset.status = on ? 'on' : 'off';
+        premiumEl.textContent = on ? 'ON' : 'OFF';
+        premiumEl.classList.toggle('on', on);
+      };
+
+      const getFav = () => localStorage.getItem('favoriteTest') === '1';
+      const setFav = (on) => {
+        localStorage.setItem('favoriteTest', on ? '1' : '0');
+        starBtn.setAttribute('aria-pressed', on ? 'true' : 'false');
+      };
+
+      // 初期化：プレミアム強制ON、★はローカルストレージから復元
+      setPremium(true);
+      setFav(getFav());
+
+      starBtn.addEventListener('click', () => {
+        const next = !getFav();
+        setFav(next);
+        log.textContent += 'star:' + next + '\n';
+      });
+
+      audioBtn.addEventListener('click', () => {
+        try {
+          const a = new Audio(); // src不要。Playwright側で play() をモック
+          const p = a.play();
+          if (p && p.catch) p.catch(() => {});
+          log.textContent += 'audio:clicked\n';
+        } catch (e) {
+          log.textContent += 'audio:error ' + e + '\n';
+        }
+      });
+    })();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
- /verify.html に辞書プレビューUIを追加（検索・シーン絞り込み）
- /verify.css にカード用スタイルを追加
- /verify.js を辞書読み込み＆描画対応に更新
- public/data/scenes/scene28.json を追加（サンプル）
- public/data/dictionary.json を生成（scenes からのマージ）
- translation フィールドを安全に除去（JSON軽量化）
