### PR TITLE
fix(ux): robust audio & favorite rebind via delegation + glyph wrapping; survive safe-text DOM rebuild

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -15,3 +15,5 @@
   <p style="margin-top:16px"><a href="/verify.html">verify.html</a></p>
 </body>
 </html>
+<script defer src="/safe-text.js"></script>
+<script defer src="/ux-bind.js"></script>

--- a/public/style.css
+++ b/public/style.css
@@ -1,0 +1,4 @@
+﻿.js-audio, .js-fav {
+  background: none; border: none; padding: 0; margin: 0 0.1em;
+  font: inherit; line-height: inherit; cursor: pointer;
+}


### PR DESCRIPTION
## What
- 音声再生（🔊）/ お気に入り（★/☆）を、イベント委譲＋グリフ自動ラップで確実に動作。
- DOM再構成（safe-text.js 等）後でも機能が剥がれない設計。

## Changes
- public/ux-bind.js 追加（音声再生＋お気に入りの後付けバインド）
- public/index.html に <script defer src="/ux-bind.js"></script> 追加（末尾）
- public/style.css に .js-audio/.js-fav の最小スタイル追加（見た目維持）

## Test Plan
- 任意の例で 🔊 クリック → MP3/data-audio があれば再生、無ければ Web Speech API(ja-JP)
- ★/☆ クリック → ★にトグル → リロード後も状態保持（localStorage）
- No.表記は No.xxx / translation 非表示 / romaji 大文字＆句読点なし＆《…》保持（safe-text.js適用時）

## Risks
- なし（追加ファイル＋読み込み行のみ。既存文言は非改変）

## Rollback
- PRを Revert で即時復旧可能
