### PR TITLE
fix(verify): replace verify-safe-shim.js with Unicode-safe sanitize (…

### DIFF
--- a/public/verify-safe-shim.js
+++ b/public/verify-safe-shim.js
@@ -1,29 +1,26 @@
-﻿/* verify-safe-shim.js (v7)
-   - window.toText があれば優先使用
-   - なければ ASCII のみを残す簡易 toText にフォールバック
-   - window.asciiOnly / window.verifySafeSetText を提供
-*/
-(function(){
-  try {
-    var hasToText = (typeof window !== "undefined") && typeof window.toText === "function";
-    var fallbackToText = function(input){
-      var s = String(input == null ? "" : input);
-      // 改行やタブは保持、ASCII範囲外（0x20〜0x7E 以外）は除去
-      return s.replace(/[^\x20-\x7E\r\n\t]/g, "");
-    };
-    var _toText = hasToText ? window.toText : fallbackToText;
-    window.asciiOnly = function(s){ return _toText(s); };
+/* verify-safe-shim.js — Unicode-safe sanitize (keeps Japanese), escapes only dangerous chars.
+ * Use with textContent/asText only (never innerHTML).
+ */
+"use strict";
 
-    if (typeof window.__verifyShimPatched === "undefined") {
-      window.__verifyShimPatched = true;
-      var bindText = function(node, val){
-        if (!node) return;
-        var txt = _toText(val);
-        if ("textContent" in node) node.textContent = txt;
-        else if ("innerText" in node) node.innerText = txt;
-        else if ("innerHTML" in node) node.innerHTML = txt.replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;");
-      };
-      window.verifySafeSetText = bindText;
-    }
-  } catch(e) { /* no-op */ }
-})();
+/** Escape minimal HTML-dangerous characters while keeping all Unicode (NFC). */
+export function sanitizeUnicode(input) {
+  const str = String(input).normalize("NFC");
+  const map = { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;", "/": "&#x2F;" };
+  return str.replace(/[&<>"'/]/g, ch => map[ch]); // keep all Unicode, escape dangerous only
+}
+
+/** Convenience wrapper */
+export function safeText(input) {
+  return sanitizeUnicode(input);
+}
+
+const SafeShim = { sanitizeUnicode, safeText };
+export default SafeShim;
+
+// Optional UMD-lite exposure for non-module consumers
+try {
+  if (typeof window !== "undefined") {
+    window.SafeShim = window.SafeShim || SafeShim;
+  }
+} catch (_e) { /* no-op */ }


### PR DESCRIPTION
日本語が文字化けしない（数シーンを斜め見）

番号が textContent/asText で表示

translation は非表示のまま

★：1例目以降も ON/OFF が効く（3例×2シーンで確認）

🔊：複数例で再生できる／シーン切替後も再生可