### PR TITLE
Fix: Onomatopoeia TTS reads JPSEN only (JP native), with cache-bust

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -87,6 +87,6 @@
     <button class="footer-btn" onclick="window.open('terms-en.html','_blank')">Terms of Service</button>
     <button class="footer-btn" onclick="window.open('privacy-en.html','_blank')">Privacy Policy</button>
   </footer>
-  <script src="script.js"></script>
+  <script src="script.js?v=tts-jpsen-final"></script>
 </body>
 </html>

--- a/public/onomatopoeia-examples.html
+++ b/public/onomatopoeia-examples.html
@@ -43,6 +43,7 @@
   <script src="translation-api.js"></script>
   <script src="translation-batch.js"></script>
   <script src="translation-cache.js"></script>
+  <script src="script.js?v=tts-jpsen-final"></script>
   <script>
     let onomatopoeiaData = [];
     let currentScene = '';
@@ -222,7 +223,7 @@
               <div class="item-number">${item.id}</div>
               <div class="item-actions" style="display:inline-flex;align-items:center;">
                 ${isTTSEnabled ? `
-                  <button class="speak-btn" onclick="playAudio('${mainText.replace(/'/g, "\\'")}')" aria-label="音声再生" style="background:none;border:none;cursor:pointer;font-size:1.2em;margin-left:12px;" data-card-control="true">
+                  <button class="speak-btn" onclick="event.stopImmediatePropagation(); return playOnomatopoeiaFromDictionary(${item.id})" aria-label="音声再生" style="background:none;border:none;cursor:pointer;font-size:1.2em;margin-left:12px;" data-card-control="true">
                     🔊
                   </button>
                 ` : ''}

--- a/public/script.js
+++ b/public/script.js
@@ -306,6 +306,28 @@ async function loadOnomatopoeiaData() {
     }));
 
     console.log(`📚 Loaded ${onomatopoeiaData.length} onomatopoeia entries`);
+
+    // === Onomatopoeia TTS: 日本語原文を固定保持（翻訳で上書きされない）
+    const JPSEN_MAP = new Map(onomatopoeiaData.map(it => [it.id, it.jpsen]));
+    // （デバッグ用）必要ならウィンドウへ露出
+    if (typeof window !== 'undefined') window.__JPSEN_MAP__ = JPSEN_MAP;
+
+    // オノマトペ辞典専用：表示は翻訳のまま、音声は必ず jpsen（日本語原文）
+    window.playOnomatopoeiaFromDictionary = function (itemId) {
+      try {
+        const jps = JPSEN_MAP.get(Number(itemId));
+        if (!jps) { console.warn(`jpsen not found: ID=${itemId}`); return; }
+        try { speechSynthesis.cancel(); } catch (_) {}
+        const u = new SpeechSynthesisUtterance(jps);
+        u.lang = 'ja-JP';
+        u.rate = (typeof speechSpeed === 'number' ? speechSpeed : 1);
+        u.pitch = 1.0;
+        u.volume = 0.9;
+        speechSynthesis.speak(u);
+      } catch (e) {
+        console.error('onomatopoeia TTS error:', e);
+      }
+    };
   } catch (error) {
     console.error('オノマトペデータの読み込みに失敗:', error);
     onomatopoeiaData = [];
@@ -747,7 +769,7 @@ function renderScene() {
         <div class="message-header">
           <span class="message-number" style="font-weight:bold;margin-right:8px;">${messageId}.</span>
           <div class="message-actions" style="display:inline-flex;align-items:center;">
-            <button class="speak-btn" style="margin-left:12px;background:none;border:none;cursor:pointer;font-size:1.2em;" onclick="playAudioWithFallback('', '${escape_for_javascript((msg.ja || '').replace(/<[^>]+>/g, ''))}', 'ja-JP')" aria-label="音声再生" data-card-control="true">🔊</button>
+            <button class="speak-btn" style="margin-left:12px;background:none;border:none;cursor:pointer;font-size:1.2em;" onclick="playAudioWithFallback('', '${escape_for_javascript((msg.ja || msg.jpsen || '').replace(/<[^>]+>/g, ''))}', 'ja-JP')" aria-label="音声再生" data-card-control="true">🔊</button>
           </div>
         </div>
         <div class="message-content" style="display:inline-block;">
@@ -1113,21 +1135,6 @@ function playTextWithTTS(text, language = "ja-JP") {
   }
 }
 
-// オノマトペ辞典専用の音声再生関数（新規作成）
-function playOnomatopoeiaFromDictionary(itemId) {
-  try {
-    // dictionary.jsonから該当するitemを検索
-    const item = onomatopoeiaData.find(item => item.id === itemId);
-    if (item && item.jpsen) {
-      console.log(`🎵 オノマトペ辞典音声再生: ID=${itemId}, jpsen=${item.jpsen}`);
-      playAudioWithFallback('', item.jpsen, 'ja-JP');
-    } else {
-      console.warn(`⚠️ オノマトペ辞典データが見つかりません: ID=${itemId}`);
-    }
-  } catch (error) {
-    console.error("❌ オノマトペ辞典音声再生エラー:", error);
-  }
-}
 
 // 音声再生機能の状態確認
 function checkAudioCapabilities() {


### PR DESCRIPTION
  • Add immutable JPSEN_MAP
  • window.* TTS handler (direct ja-JP)
  • Stop delegated handlers on 🔊
  • Cache-bust script.js
  
  Ensures translation layer never affects audio.